### PR TITLE
fix(security): remove vulnerable deps and add SSRF/sandbox hardening

### DIFF
--- a/dist/lib/parser.js
+++ b/dist/lib/parser.js
@@ -42,6 +42,7 @@ exports.parseWechatArticle = parseWechatArticle;
 exports.buildMeta = buildMeta;
 const cheerio = __importStar(require("cheerio"));
 const puppeteer_core_1 = __importDefault(require("puppeteer-core"));
+const url_1 = require("./url");
 const DEFAULT_NAVIGATION_TIMEOUT_MS = 60000;
 const DEFAULT_CONTENT_TIMEOUT_MS = 30000;
 /**
@@ -49,14 +50,15 @@ const DEFAULT_CONTENT_TIMEOUT_MS = 30000;
  * 微信公众号有较强的反爬机制，需要使用无头浏览器
  */
 async function fetchArticleHtml(url) {
+    (0, url_1.assertSafeArticleUrl)(url);
     const launchOptions = {
         headless: true,
         args: [
-            '--no-sandbox',
-            '--disable-setuid-sandbox',
             '--disable-dev-shm-usage',
             '--disable-accelerated-2d-canvas',
             '--disable-gpu',
+            // 仅在 root / 容器等无法使用沙箱的环境才关闭 Chrome 沙箱。
+            ...(shouldDisableSandbox() ? ['--no-sandbox', '--disable-setuid-sandbox'] : []),
         ],
     };
     if (process.env.WECHAT_NOTEBANK_CHROME_PATH) {
@@ -99,6 +101,16 @@ async function fetchArticleHtmlFromPage(page, url) {
         // 继续返回页面内容，让解析层给出统一的文章结构错误。
     });
     return await page.content();
+}
+/**
+ * 默认保留 Chrome 沙箱。仅当显式 opt-in，或以 root 身份运行
+ * （沙箱无法在 root 下启动）时才关闭。
+ */
+function shouldDisableSandbox() {
+    if (process.env.WECHAT_NOTEBANK_NO_SANDBOX === '1') {
+        return true;
+    }
+    return typeof process.getuid === 'function' && process.getuid() === 0;
 }
 function isNavigationTimeoutError(error) {
     if (!(error instanceof Error)) {

--- a/dist/lib/url.js
+++ b/dist/lib/url.js
@@ -1,0 +1,61 @@
+"use strict";
+/**
+ * 抓取地址的安全校验：只允许 http/https 公网地址，
+ * 阻断 file://、内网 / 回环 / 链路本地地址以及云元数据端点，避免 SSRF 与本地文件读取。
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.assertSafeArticleUrl = assertSafeArticleUrl;
+// 私有 / 回环 / 链路本地等不应被抓取的网段
+const BLOCKED_IPV4_PATTERNS = [
+    /^127\./, // 回环
+    /^10\./, // 私有 A
+    /^192\.168\./, // 私有 C
+    /^169\.254\./, // 链路本地 / 云元数据 169.254.169.254
+    /^0\./, // 当前网络
+    /^192\.0\.2\./, // TEST-NET
+];
+function isBlockedIpv4(host) {
+    // 172.16.0.0 – 172.31.255.255（私有 B）
+    const privateB = host.match(/^172\.(\d{1,3})\./);
+    if (privateB) {
+        const second = Number(privateB[1]);
+        if (second >= 16 && second <= 31) {
+            return true;
+        }
+    }
+    return BLOCKED_IPV4_PATTERNS.some((pattern) => pattern.test(host));
+}
+function isBlockedHostname(hostname) {
+    const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    if (host === 'localhost' || host.endsWith('.localhost')) {
+        return true;
+    }
+    // IPv6 回环 / 未指定地址，以及 IPv4 映射的回环
+    if (host === '::1' || host === '::' || host.includes('::ffff:127.')) {
+        return true;
+    }
+    // IPv6 唯一本地地址 (fc00::/7) 与链路本地 (fe80::/10)
+    if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)) {
+        return true;
+    }
+    return isBlockedIpv4(host);
+}
+/**
+ * 校验抓取地址；不合法时抛出带原因的错误。
+ */
+function assertSafeArticleUrl(rawUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    }
+    catch {
+        throw new Error(`无效的链接: ${rawUrl}`);
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error(`不支持的协议 "${parsed.protocol}"，只允许 http/https 链接`);
+    }
+    if (isBlockedHostname(parsed.hostname)) {
+        throw new Error(`拒绝抓取内网 / 本地地址: ${parsed.hostname}`);
+    }
+    return parsed;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "axios": "^1.6.5",
         "cheerio": "^1.0.0",
         "fs-extra": "^11.2.0",
         "gray-matter": "^4.0.3",
         "inquirer": "^8.2.5",
         "puppeteer-core": "^24.43.0",
-        "xlsx": "^0.18.5"
+        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
       },
       "bin": {
         "alskai-notebank": "dist/index.js",
@@ -154,15 +153,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -230,23 +220,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT"
-    },
-    "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/b4a": {
@@ -433,32 +406,6 @@
         "node": "*"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -609,15 +556,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -635,30 +573,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "license": "MIT",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/css-select": {
       "version": "5.2.2",
@@ -740,15 +654,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/devtools-protocol": {
       "version": "0.0.1608973",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
@@ -810,20 +715,6 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -862,51 +753,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/escalade": {
@@ -1050,51 +896,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -1109,15 +910,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -1125,43 +917,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -1193,18 +948,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -1233,45 +976,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/htmlparser2": {
@@ -1508,36 +1212,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -1754,15 +1428,6 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
-    "node_modules/proxy-from-env": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/pump": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -1955,18 +1620,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
     },
     "node_modules/streamx": {
       "version": "2.25.0",
@@ -2191,24 +1844,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -2230,9 +1865,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2251,19 +1886,10 @@
       }
     },
     "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
+      "version": "0.20.3",
+      "resolved": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz",
+      "integrity": "sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
       "bin": {
         "xlsx": "bin/xlsx.njs"
       },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node tests/fetch-args.test.js && node tests/resolve-archive-path.test.js && node tests/storage.test.js && node tests/importer.test.js && node tests/parser.test.js && node tests/fetch-html.test.js",
+    "test": "npm run build && node tests/fetch-args.test.js && node tests/resolve-archive-path.test.js && node tests/storage.test.js && node tests/importer.test.js && node tests/parser.test.js && node tests/fetch-html.test.js && node tests/url.test.js",
     "prepublishOnly": "npm run build",
     "start": "node dist/index.js"
   },
@@ -38,13 +38,12 @@
   "homepage": "https://github.com/Albert-Lsk/wechat-notebank#readme",
   "license": "MIT",
   "dependencies": {
-    "axios": "^1.6.5",
     "cheerio": "^1.0.0",
     "fs-extra": "^11.2.0",
     "gray-matter": "^4.0.3",
     "inquirer": "^8.2.5",
     "puppeteer-core": "^24.43.0",
-    "xlsx": "^0.18.5"
+    "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -1,6 +1,7 @@
 import * as cheerio from 'cheerio';
 import puppeteer, { LaunchOptions } from 'puppeteer-core';
 import { ParseResult, ArticleMeta } from '../types';
+import { assertSafeArticleUrl } from './url';
 
 const DEFAULT_NAVIGATION_TIMEOUT_MS = 60000;
 const DEFAULT_CONTENT_TIMEOUT_MS = 30000;
@@ -19,14 +20,16 @@ interface ArticleBrowserPage {
  * 微信公众号有较强的反爬机制，需要使用无头浏览器
  */
 export async function fetchArticleHtml(url: string): Promise<string> {
+  assertSafeArticleUrl(url);
+
   const launchOptions: LaunchOptions = {
     headless: true,
     args: [
-      '--no-sandbox',
-      '--disable-setuid-sandbox',
       '--disable-dev-shm-usage',
       '--disable-accelerated-2d-canvas',
       '--disable-gpu',
+      // 仅在 root / 容器等无法使用沙箱的环境才关闭 Chrome 沙箱。
+      ...(shouldDisableSandbox() ? ['--no-sandbox', '--disable-setuid-sandbox'] : []),
     ],
   };
 
@@ -83,6 +86,18 @@ export async function fetchArticleHtmlFromPage(
   });
 
   return await page.content();
+}
+
+/**
+ * 默认保留 Chrome 沙箱。仅当显式 opt-in，或以 root 身份运行
+ * （沙箱无法在 root 下启动）时才关闭。
+ */
+function shouldDisableSandbox(): boolean {
+  if (process.env.WECHAT_NOTEBANK_NO_SANDBOX === '1') {
+    return true;
+  }
+
+  return typeof process.getuid === 'function' && process.getuid() === 0;
 }
 
 function isNavigationTimeoutError(error: unknown): boolean {

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -1,0 +1,69 @@
+/**
+ * 抓取地址的安全校验：只允许 http/https 公网地址，
+ * 阻断 file://、内网 / 回环 / 链路本地地址以及云元数据端点，避免 SSRF 与本地文件读取。
+ */
+
+// 私有 / 回环 / 链路本地等不应被抓取的网段
+const BLOCKED_IPV4_PATTERNS: RegExp[] = [
+  /^127\./, // 回环
+  /^10\./, // 私有 A
+  /^192\.168\./, // 私有 C
+  /^169\.254\./, // 链路本地 / 云元数据 169.254.169.254
+  /^0\./, // 当前网络
+  /^192\.0\.2\./, // TEST-NET
+];
+
+function isBlockedIpv4(host: string): boolean {
+  // 172.16.0.0 – 172.31.255.255（私有 B）
+  const privateB = host.match(/^172\.(\d{1,3})\./);
+  if (privateB) {
+    const second = Number(privateB[1]);
+    if (second >= 16 && second <= 31) {
+      return true;
+    }
+  }
+
+  return BLOCKED_IPV4_PATTERNS.some((pattern) => pattern.test(host));
+}
+
+function isBlockedHostname(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+
+  if (host === 'localhost' || host.endsWith('.localhost')) {
+    return true;
+  }
+
+  // IPv6 回环 / 未指定地址，以及 IPv4 映射的回环
+  if (host === '::1' || host === '::' || host.includes('::ffff:127.')) {
+    return true;
+  }
+
+  // IPv6 唯一本地地址 (fc00::/7) 与链路本地 (fe80::/10)
+  if (/^f[cd][0-9a-f]{2}:/.test(host) || /^fe[89ab][0-9a-f]:/.test(host)) {
+    return true;
+  }
+
+  return isBlockedIpv4(host);
+}
+
+/**
+ * 校验抓取地址；不合法时抛出带原因的错误。
+ */
+export function assertSafeArticleUrl(rawUrl: string): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`无效的链接: ${rawUrl}`);
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw new Error(`不支持的协议 "${parsed.protocol}"，只允许 http/https 链接`);
+  }
+
+  if (isBlockedHostname(parsed.hostname)) {
+    throw new Error(`拒绝抓取内网 / 本地地址: ${parsed.hostname}`);
+  }
+
+  return parsed;
+}

--- a/tests/url.test.js
+++ b/tests/url.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const { assertSafeArticleUrl } = require('../dist/lib/url');
+
+function run() {
+  // 合法的公网 https 链接应通过
+  assert.strictEqual(
+    assertSafeArticleUrl('https://mp.weixin.qq.com/s/abc').hostname,
+    'mp.weixin.qq.com'
+  );
+  assert.doesNotThrow(() => assertSafeArticleUrl('http://example.com/article'));
+
+  // 非 http(s) 协议应被拒绝（含本地文件读取）
+  assert.throws(() => assertSafeArticleUrl('file:///etc/passwd'), /协议/);
+  assert.throws(() => assertSafeArticleUrl('ftp://example.com/x'), /协议/);
+  assert.throws(() => assertSafeArticleUrl('not-a-url'), /无效的链接/);
+
+  // SSRF：回环 / 内网 / 链路本地 / 云元数据应被拒绝
+  const blocked = [
+    'http://127.0.0.1/admin',
+    'http://localhost:8080/',
+    'http://169.254.169.254/latest/meta-data/',
+    'http://10.0.0.5/',
+    'http://192.168.1.1/',
+    'http://172.16.0.1/',
+    'http://172.31.255.255/',
+    'http://[::1]/',
+  ];
+  for (const url of blocked) {
+    assert.throws(() => assertSafeArticleUrl(url), /内网|本地/, `should block ${url}`);
+  }
+
+  // 公网范围的 172（非 16-31 段）应通过
+  assert.doesNotThrow(() => assertSafeArticleUrl('http://172.32.0.1/'));
+
+  console.log('url validation tests passed');
+}
+
+run();


### PR DESCRIPTION
## 背景
对项目做安全体检后发现的问题修复。

## 改动
**依赖漏洞（4 项 → 0 项，`npm audit` 已清零）**
- 删除未使用的 `axios`（消除 20+ 高/中危 CVE，连带移除 `follow-redirects`）
- 用官方 SheetJS `xlsx-0.20.3` 替换已弃维的 npm `xlsx@0.18.5`（修复原型污染 + ReDoS）
- 升级传递依赖 `ws` 至已修复版本

**代码加固**
- 新增 `assertSafeArticleUrl()`：拦截非 http(s) 协议（`file://`）及指向回环/内网/链路本地（含云元数据 `169.254.169.254`）的 SSRF 地址
- Chrome 沙箱默认开启，仅 root 或 `WECHAT_NOTEBANK_NO_SANDBOX=1` 时关闭

**测试**
- 新增 `tests/url.test.js` 覆盖 URL 校验，已接入 `npm test`

## 验证
- `npm test` 全部通过
- `npm audit` → 0 vulnerabilities